### PR TITLE
Added Iterator->rewind()

### DIFF
--- a/Uploader/Chunk/Storage/FilesystemStorage.php
+++ b/Uploader/Chunk/Storage/FilesystemStorage.php
@@ -57,6 +57,7 @@ class FilesystemStorage implements ChunkStorageInterface
         }
 
         $iterator = $chunks->getIterator();
+        $iterator->rewind();
 
         $base = $iterator->current();
         $iterator->next();


### PR DESCRIPTION
Fixed `getPathname()` FatalError when tried to assemble chunks got from FineUploader.

I suspect the error is somewhere else, because the `current()` element should be the first after Instanciating the iterator, but this fixes the issue.
